### PR TITLE
fix: add arch override for git-cliff arm64 release

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -33,7 +33,14 @@ list_all_versions() {
 }
 
 get_arch() {
-	uname -m
+	local arch
+	arch=${ARCH:-"$(uname -m)"}
+
+	case ${arch} in
+	arm64) arch="aarch64" ;;
+	esac
+
+	echo "$arch"
 }
 
 get_os() {


### PR DESCRIPTION
git-cliff publishes darwin arm64 distro as darwin aarch64.
this fixes the release path as well as allow overrides of arch by using `ARCH` env.